### PR TITLE
fix: bundle install msg

### DIFF
--- a/patches/@agoric+cosmic-proto+0.3.0.patch
+++ b/patches/@agoric+cosmic-proto+0.3.0.patch
@@ -1,0 +1,647 @@
+diff --git a/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/msgs.d.ts b/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/msgs.d.ts
+index 5d5f60d..e71a311 100644
+--- a/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/msgs.d.ts
++++ b/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/msgs.d.ts
+@@ -47,6 +47,13 @@ export interface MsgProvisionResponse {}
+ export interface MsgInstallBundle {
+   bundle: string;
+   submitter: Uint8Array;
++  /**
++   * Either bundle or compressed_bundle will be set.
++   * Default compression algorithm is gzip.
++   */
++  compressedBundle: Uint8Array;
++  /** Size in bytes of uncompression of compressed_bundle. */
++  uncompressedSize: Long;
+ }
+ /**
+  * MsgInstallBundleResponse is an empty acknowledgement that an install bundle
+@@ -355,10 +362,91 @@ export declare const MsgInstallBundle: {
+     I extends {
+       bundle?: string | undefined;
+       submitter?: Uint8Array | undefined;
++      compressedBundle?: Uint8Array | undefined;
++      uncompressedSize?: string | number | Long | undefined;
+     } & {
+       bundle?: string | undefined;
+       submitter?: Uint8Array | undefined;
+-    } & { [K in Exclude<keyof I, keyof MsgInstallBundle>]: never },
++      compressedBundle?: Uint8Array | undefined;
++      uncompressedSize?:
++        | string
++        | number
++        | (Long & {
++            high: number;
++            low: number;
++            unsigned: boolean;
++            add: (addend: string | number | Long) => Long;
++            and: (other: string | number | Long) => Long;
++            compare: (other: string | number | Long) => number;
++            comp: (other: string | number | Long) => number;
++            divide: (divisor: string | number | Long) => Long;
++            div: (divisor: string | number | Long) => Long;
++            equals: (other: string | number | Long) => boolean;
++            eq: (other: string | number | Long) => boolean;
++            getHighBits: () => number;
++            getHighBitsUnsigned: () => number;
++            getLowBits: () => number;
++            getLowBitsUnsigned: () => number;
++            getNumBitsAbs: () => number;
++            greaterThan: (other: string | number | Long) => boolean;
++            gt: (other: string | number | Long) => boolean;
++            greaterThanOrEqual: (other: string | number | Long) => boolean;
++            gte: (other: string | number | Long) => boolean;
++            ge: (other: string | number | Long) => boolean;
++            isEven: () => boolean;
++            isNegative: () => boolean;
++            isOdd: () => boolean;
++            isPositive: () => boolean;
++            isZero: () => boolean;
++            eqz: () => boolean;
++            lessThan: (other: string | number | Long) => boolean;
++            lt: (other: string | number | Long) => boolean;
++            lessThanOrEqual: (other: string | number | Long) => boolean;
++            lte: (other: string | number | Long) => boolean;
++            le: (other: string | number | Long) => boolean;
++            modulo: (other: string | number | Long) => Long;
++            mod: (other: string | number | Long) => Long;
++            rem: (other: string | number | Long) => Long;
++            multiply: (multiplier: string | number | Long) => Long;
++            mul: (multiplier: string | number | Long) => Long;
++            negate: () => Long;
++            neg: () => Long;
++            not: () => Long;
++            countLeadingZeros: () => number;
++            clz: () => number;
++            countTrailingZeros: () => number;
++            ctz: () => number;
++            notEquals: (other: string | number | Long) => boolean;
++            neq: (other: string | number | Long) => boolean;
++            ne: (other: string | number | Long) => boolean;
++            or: (other: string | number | Long) => Long;
++            shiftLeft: (numBits: number | Long) => Long;
++            shl: (numBits: number | Long) => Long;
++            shiftRight: (numBits: number | Long) => Long;
++            shr: (numBits: number | Long) => Long;
++            shiftRightUnsigned: (numBits: number | Long) => Long;
++            shru: (numBits: number | Long) => Long;
++            shr_u: (numBits: number | Long) => Long;
++            rotateLeft: (numBits: number | Long) => Long;
++            rotl: (numBits: number | Long) => Long;
++            rotateRight: (numBits: number | Long) => Long;
++            rotr: (numBits: number | Long) => Long;
++            subtract: (subtrahend: string | number | Long) => Long;
++            sub: (subtrahend: string | number | Long) => Long;
++            toInt: () => number;
++            toNumber: () => number;
++            toBytes: (le?: boolean | undefined) => number[];
++            toBytesLE: () => number[];
++            toBytesBE: () => number[];
++            toSigned: () => Long;
++            toString: (radix?: number | undefined) => string;
++            toUnsigned: () => Long;
++            xor: (other: string | number | Long) => Long;
++          } & {
++            [K in Exclude<keyof I['uncompressedSize'], keyof Long>]: never;
++          })
++        | undefined;
++    } & { [K_1 in Exclude<keyof I, keyof MsgInstallBundle>]: never },
+   >(
+     object: I,
+   ): MsgInstallBundle;
+@@ -418,7 +506,7 @@ interface Rpc {
+     data: Uint8Array,
+   ): Promise<Uint8Array>;
+ }
+-declare type Builtin =
++type Builtin =
+   | Date
+   | Function
+   | Uint8Array
+@@ -426,7 +514,7 @@ declare type Builtin =
+   | number
+   | boolean
+   | undefined;
+-export declare type DeepPartial<T> = T extends Builtin
++export type DeepPartial<T> = T extends Builtin
+   ? T
+   : T extends Long
+   ? string | number | Long
+@@ -439,8 +527,8 @@ export declare type DeepPartial<T> = T extends Builtin
+       [K in keyof T]?: DeepPartial<T[K]>;
+     }
+   : Partial<T>;
+-declare type KeysOfUnion<T> = T extends T ? keyof T : never;
+-export declare type Exact<P, I extends P> = P extends Builtin
++type KeysOfUnion<T> = T extends T ? keyof T : never;
++export type Exact<P, I extends P> = P extends Builtin
+   ? P
+   : P & {
+       [K in keyof P]: Exact<P[K], I[K]>;
+diff --git a/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/msgs.js b/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/msgs.js
+index 878d26b..7f60095 100644
+--- a/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/msgs.js
++++ b/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/msgs.js
+@@ -64,10 +64,10 @@ export const MsgDeliverInbound = {
+   fromJSON(object) {
+     return {
+       messages: Array.isArray(object?.messages)
+-        ? object.messages.map((e) => String(e))
++        ? object.messages.map(e => String(e))
+         : [],
+       nums: Array.isArray(object?.nums)
+-        ? object.nums.map((e) => Long.fromValue(e))
++        ? object.nums.map(e => Long.fromValue(e))
+         : [],
+       ack: isSet(object.ack) ? Long.fromValue(object.ack) : Long.UZERO,
+       submitter: isSet(object.submitter)
+@@ -78,12 +78,12 @@ export const MsgDeliverInbound = {
+   toJSON(message) {
+     const obj = {};
+     if (message.messages) {
+-      obj.messages = message.messages.map((e) => e);
++      obj.messages = message.messages.map(e => e);
+     } else {
+       obj.messages = [];
+     }
+     if (message.nums) {
+-      obj.nums = message.nums.map((e) => (e || Long.UZERO).toString());
++      obj.nums = message.nums.map(e => (e || Long.UZERO).toString());
+     } else {
+       obj.nums = [];
+     }
+@@ -97,8 +97,8 @@ export const MsgDeliverInbound = {
+   },
+   fromPartial(object) {
+     const message = createBaseMsgDeliverInbound();
+-    message.messages = object.messages?.map((e) => e) || [];
+-    message.nums = object.nums?.map((e) => Long.fromValue(e)) || [];
++    message.messages = object.messages?.map(e => e) || [];
++    message.nums = object.nums?.map(e => Long.fromValue(e)) || [];
+     message.ack =
+       object.ack !== undefined && object.ack !== null
+         ? Long.fromValue(object.ack)
+@@ -378,7 +378,7 @@ export const MsgProvision = {
+         ? bytesFromBase64(object.address)
+         : new Uint8Array(),
+       powerFlags: Array.isArray(object?.powerFlags)
+-        ? object.powerFlags.map((e) => String(e))
++        ? object.powerFlags.map(e => String(e))
+         : [],
+       submitter: isSet(object.submitter)
+         ? bytesFromBase64(object.submitter)
+@@ -393,7 +393,7 @@ export const MsgProvision = {
+         message.address !== undefined ? message.address : new Uint8Array(),
+       ));
+     if (message.powerFlags) {
+-      obj.powerFlags = message.powerFlags.map((e) => e);
++      obj.powerFlags = message.powerFlags.map(e => e);
+     } else {
+       obj.powerFlags = [];
+     }
+@@ -407,7 +407,7 @@ export const MsgProvision = {
+     const message = createBaseMsgProvision();
+     message.nickname = object.nickname ?? '';
+     message.address = object.address ?? new Uint8Array();
+-    message.powerFlags = object.powerFlags?.map((e) => e) || [];
++    message.powerFlags = object.powerFlags?.map(e => e) || [];
+     message.submitter = object.submitter ?? new Uint8Array();
+     return message;
+   },
+@@ -446,7 +446,12 @@ export const MsgProvisionResponse = {
+   },
+ };
+ function createBaseMsgInstallBundle() {
+-  return { bundle: '', submitter: new Uint8Array() };
++  return {
++    bundle: '',
++    submitter: new Uint8Array(),
++    compressedBundle: new Uint8Array(),
++    uncompressedSize: Long.ZERO,
++  };
+ }
+ export const MsgInstallBundle = {
+   encode(message, writer = _m0.Writer.create()) {
+@@ -456,6 +461,12 @@ export const MsgInstallBundle = {
+     if (message.submitter.length !== 0) {
+       writer.uint32(18).bytes(message.submitter);
+     }
++    if (message.compressedBundle.length !== 0) {
++      writer.uint32(26).bytes(message.compressedBundle);
++    }
++    if (!message.uncompressedSize.isZero()) {
++      writer.uint32(32).int64(message.uncompressedSize);
++    }
+     return writer;
+   },
+   decode(input, length) {
+@@ -471,6 +482,12 @@ export const MsgInstallBundle = {
+         case 2:
+           message.submitter = reader.bytes();
+           break;
++        case 3:
++          message.compressedBundle = reader.bytes();
++          break;
++        case 4:
++          message.uncompressedSize = reader.int64();
++          break;
+         default:
+           reader.skipType(tag & 7);
+           break;
+@@ -484,6 +501,12 @@ export const MsgInstallBundle = {
+       submitter: isSet(object.submitter)
+         ? bytesFromBase64(object.submitter)
+         : new Uint8Array(),
++      compressedBundle: isSet(object.compressedBundle)
++        ? bytesFromBase64(object.compressedBundle)
++        : new Uint8Array(),
++      uncompressedSize: isSet(object.uncompressedSize)
++        ? Long.fromValue(object.uncompressedSize)
++        : Long.ZERO,
+     };
+   },
+   toJSON(message) {
+@@ -493,12 +516,27 @@ export const MsgInstallBundle = {
+       (obj.submitter = base64FromBytes(
+         message.submitter !== undefined ? message.submitter : new Uint8Array(),
+       ));
++    message.compressedBundle !== undefined &&
++      (obj.compressedBundle = base64FromBytes(
++        message.compressedBundle !== undefined
++          ? message.compressedBundle
++          : new Uint8Array(),
++      ));
++    message.uncompressedSize !== undefined &&
++      (obj.uncompressedSize = (
++        message.uncompressedSize || Long.ZERO
++      ).toString());
+     return obj;
+   },
+   fromPartial(object) {
+     const message = createBaseMsgInstallBundle();
+     message.bundle = object.bundle ?? '';
+     message.submitter = object.submitter ?? new Uint8Array();
++    message.compressedBundle = object.compressedBundle ?? new Uint8Array();
++    message.uncompressedSize =
++      object.uncompressedSize !== undefined && object.uncompressedSize !== null
++        ? Long.fromValue(object.uncompressedSize)
++        : Long.ZERO;
+     return message;
+   },
+ };
+@@ -550,35 +588,35 @@ export class MsgClientImpl {
+   InstallBundle(request) {
+     const data = MsgInstallBundle.encode(request).finish();
+     const promise = this.rpc.request(this.service, 'InstallBundle', data);
+-    return promise.then((data) =>
++    return promise.then(data =>
+       MsgInstallBundleResponse.decode(new _m0.Reader(data)),
+     );
+   }
+   DeliverInbound(request) {
+     const data = MsgDeliverInbound.encode(request).finish();
+     const promise = this.rpc.request(this.service, 'DeliverInbound', data);
+-    return promise.then((data) =>
++    return promise.then(data =>
+       MsgDeliverInboundResponse.decode(new _m0.Reader(data)),
+     );
+   }
+   WalletAction(request) {
+     const data = MsgWalletAction.encode(request).finish();
+     const promise = this.rpc.request(this.service, 'WalletAction', data);
+-    return promise.then((data) =>
++    return promise.then(data =>
+       MsgWalletActionResponse.decode(new _m0.Reader(data)),
+     );
+   }
+   WalletSpendAction(request) {
+     const data = MsgWalletSpendAction.encode(request).finish();
+     const promise = this.rpc.request(this.service, 'WalletSpendAction', data);
+-    return promise.then((data) =>
++    return promise.then(data =>
+       MsgWalletSpendActionResponse.decode(new _m0.Reader(data)),
+     );
+   }
+   Provision(request) {
+     const data = MsgProvision.encode(request).finish();
+     const promise = this.rpc.request(this.service, 'Provision', data);
+-    return promise.then((data) =>
++    return promise.then(data =>
+       MsgProvisionResponse.decode(new _m0.Reader(data)),
+     );
+   }
+@@ -615,7 +653,7 @@ function base64FromBytes(arr) {
+     return globalThis.Buffer.from(arr).toString('base64');
+   } else {
+     const bin = [];
+-    arr.forEach((byte) => {
++    arr.forEach(byte => {
+       bin.push(String.fromCharCode(byte));
+     });
+     return globalThis.btoa(bin.join(''));
+diff --git a/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/swingset.d.ts b/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/swingset.d.ts
+index 9b2e99c..6aab530 100644
+--- a/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/swingset.d.ts
++++ b/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/swingset.d.ts
+@@ -111,8 +111,13 @@ export interface Egress {
+   /** TODO: Remove these power flags as they are deprecated and have no effect. */
+   powerFlags: string[];
+ }
+-/** The payload messages used by swingset state-sync */
+-export interface ExtensionSnapshotterArtifactPayload {
++/**
++ * SwingStoreArtifact encodes an artifact of a swing-store export.
++ * Artifacts may be stored or transmitted in any order. Most handlers do
++ * maintain the artifact order from their original source as an effect of how
++ * they handle the artifacts.
++ */
++export interface SwingStoreArtifact {
+   name: string;
+   data: Uint8Array;
+ }
+@@ -514,17 +519,11 @@ export declare const Egress: {
+     object: I,
+   ): Egress;
+ };
+-export declare const ExtensionSnapshotterArtifactPayload: {
+-  encode(
+-    message: ExtensionSnapshotterArtifactPayload,
+-    writer?: _m0.Writer,
+-  ): _m0.Writer;
+-  decode(
+-    input: _m0.Reader | Uint8Array,
+-    length?: number,
+-  ): ExtensionSnapshotterArtifactPayload;
+-  fromJSON(object: any): ExtensionSnapshotterArtifactPayload;
+-  toJSON(message: ExtensionSnapshotterArtifactPayload): unknown;
++export declare const SwingStoreArtifact: {
++  encode(message: SwingStoreArtifact, writer?: _m0.Writer): _m0.Writer;
++  decode(input: _m0.Reader | Uint8Array, length?: number): SwingStoreArtifact;
++  fromJSON(object: any): SwingStoreArtifact;
++  toJSON(message: SwingStoreArtifact): unknown;
+   fromPartial<
+     I extends {
+       name?: string | undefined;
+@@ -532,14 +531,12 @@ export declare const ExtensionSnapshotterArtifactPayload: {
+     } & {
+       name?: string | undefined;
+       data?: Uint8Array | undefined;
+-    } & {
+-      [K in Exclude<keyof I, keyof ExtensionSnapshotterArtifactPayload>]: never;
+-    },
++    } & { [K in Exclude<keyof I, keyof SwingStoreArtifact>]: never },
+   >(
+     object: I,
+-  ): ExtensionSnapshotterArtifactPayload;
++  ): SwingStoreArtifact;
+ };
+-declare type Builtin =
++type Builtin =
+   | Date
+   | Function
+   | Uint8Array
+@@ -547,7 +544,7 @@ declare type Builtin =
+   | number
+   | boolean
+   | undefined;
+-export declare type DeepPartial<T> = T extends Builtin
++export type DeepPartial<T> = T extends Builtin
+   ? T
+   : T extends Long
+   ? string | number | Long
+@@ -560,8 +557,8 @@ export declare type DeepPartial<T> = T extends Builtin
+       [K in keyof T]?: DeepPartial<T[K]>;
+     }
+   : Partial<T>;
+-declare type KeysOfUnion<T> = T extends T ? keyof T : never;
+-export declare type Exact<P, I extends P> = P extends Builtin
++type KeysOfUnion<T> = T extends T ? keyof T : never;
++export type Exact<P, I extends P> = P extends Builtin
+   ? P
+   : P & {
+       [K in keyof P]: Exact<P[K], I[K]>;
+diff --git a/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/swingset.js b/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/swingset.js
+index d425ff8..87caa3a 100644
+--- a/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/swingset.js
++++ b/node_modules/@agoric/cosmic-proto/dist/agoric/swingset/swingset.js
+@@ -47,7 +47,7 @@ export const CoreEvalProposal = {
+       title: isSet(object.title) ? String(object.title) : '',
+       description: isSet(object.description) ? String(object.description) : '',
+       evals: Array.isArray(object?.evals)
+-        ? object.evals.map((e) => CoreEval.fromJSON(e))
++        ? object.evals.map(e => CoreEval.fromJSON(e))
+         : [],
+     };
+   },
+@@ -57,9 +57,7 @@ export const CoreEvalProposal = {
+     message.description !== undefined &&
+       (obj.description = message.description);
+     if (message.evals) {
+-      obj.evals = message.evals.map((e) =>
+-        e ? CoreEval.toJSON(e) : undefined,
+-      );
++      obj.evals = message.evals.map(e => (e ? CoreEval.toJSON(e) : undefined));
+     } else {
+       obj.evals = [];
+     }
+@@ -69,7 +67,7 @@ export const CoreEvalProposal = {
+     const message = createBaseCoreEvalProposal();
+     message.title = object.title ?? '';
+     message.description = object.description ?? '';
+-    message.evals = object.evals?.map((e) => CoreEval.fromPartial(e)) || [];
++    message.evals = object.evals?.map(e => CoreEval.fromPartial(e)) || [];
+     return message;
+   },
+ };
+@@ -190,33 +188,33 @@ export const Params = {
+   fromJSON(object) {
+     return {
+       beansPerUnit: Array.isArray(object?.beansPerUnit)
+-        ? object.beansPerUnit.map((e) => StringBeans.fromJSON(e))
++        ? object.beansPerUnit.map(e => StringBeans.fromJSON(e))
+         : [],
+       feeUnitPrice: Array.isArray(object?.feeUnitPrice)
+-        ? object.feeUnitPrice.map((e) => Coin.fromJSON(e))
++        ? object.feeUnitPrice.map(e => Coin.fromJSON(e))
+         : [],
+       bootstrapVatConfig: isSet(object.bootstrapVatConfig)
+         ? String(object.bootstrapVatConfig)
+         : '',
+       powerFlagFees: Array.isArray(object?.powerFlagFees)
+-        ? object.powerFlagFees.map((e) => PowerFlagFee.fromJSON(e))
++        ? object.powerFlagFees.map(e => PowerFlagFee.fromJSON(e))
+         : [],
+       queueMax: Array.isArray(object?.queueMax)
+-        ? object.queueMax.map((e) => QueueSize.fromJSON(e))
++        ? object.queueMax.map(e => QueueSize.fromJSON(e))
+         : [],
+     };
+   },
+   toJSON(message) {
+     const obj = {};
+     if (message.beansPerUnit) {
+-      obj.beansPerUnit = message.beansPerUnit.map((e) =>
++      obj.beansPerUnit = message.beansPerUnit.map(e =>
+         e ? StringBeans.toJSON(e) : undefined,
+       );
+     } else {
+       obj.beansPerUnit = [];
+     }
+     if (message.feeUnitPrice) {
+-      obj.feeUnitPrice = message.feeUnitPrice.map((e) =>
++      obj.feeUnitPrice = message.feeUnitPrice.map(e =>
+         e ? Coin.toJSON(e) : undefined,
+       );
+     } else {
+@@ -225,14 +223,14 @@ export const Params = {
+     message.bootstrapVatConfig !== undefined &&
+       (obj.bootstrapVatConfig = message.bootstrapVatConfig);
+     if (message.powerFlagFees) {
+-      obj.powerFlagFees = message.powerFlagFees.map((e) =>
++      obj.powerFlagFees = message.powerFlagFees.map(e =>
+         e ? PowerFlagFee.toJSON(e) : undefined,
+       );
+     } else {
+       obj.powerFlagFees = [];
+     }
+     if (message.queueMax) {
+-      obj.queueMax = message.queueMax.map((e) =>
++      obj.queueMax = message.queueMax.map(e =>
+         e ? QueueSize.toJSON(e) : undefined,
+       );
+     } else {
+@@ -243,14 +241,14 @@ export const Params = {
+   fromPartial(object) {
+     const message = createBaseParams();
+     message.beansPerUnit =
+-      object.beansPerUnit?.map((e) => StringBeans.fromPartial(e)) || [];
++      object.beansPerUnit?.map(e => StringBeans.fromPartial(e)) || [];
+     message.feeUnitPrice =
+-      object.feeUnitPrice?.map((e) => Coin.fromPartial(e)) || [];
++      object.feeUnitPrice?.map(e => Coin.fromPartial(e)) || [];
+     message.bootstrapVatConfig = object.bootstrapVatConfig ?? '';
+     message.powerFlagFees =
+-      object.powerFlagFees?.map((e) => PowerFlagFee.fromPartial(e)) || [];
++      object.powerFlagFees?.map(e => PowerFlagFee.fromPartial(e)) || [];
+     message.queueMax =
+-      object.queueMax?.map((e) => QueueSize.fromPartial(e)) || [];
++      object.queueMax?.map(e => QueueSize.fromPartial(e)) || [];
+     return message;
+   },
+ };
+@@ -284,14 +282,14 @@ export const State = {
+   fromJSON(object) {
+     return {
+       queueAllowed: Array.isArray(object?.queueAllowed)
+-        ? object.queueAllowed.map((e) => QueueSize.fromJSON(e))
++        ? object.queueAllowed.map(e => QueueSize.fromJSON(e))
+         : [],
+     };
+   },
+   toJSON(message) {
+     const obj = {};
+     if (message.queueAllowed) {
+-      obj.queueAllowed = message.queueAllowed.map((e) =>
++      obj.queueAllowed = message.queueAllowed.map(e =>
+         e ? QueueSize.toJSON(e) : undefined,
+       );
+     } else {
+@@ -302,7 +300,7 @@ export const State = {
+   fromPartial(object) {
+     const message = createBaseState();
+     message.queueAllowed =
+-      object.queueAllowed?.map((e) => QueueSize.fromPartial(e)) || [];
++      object.queueAllowed?.map(e => QueueSize.fromPartial(e)) || [];
+     return message;
+   },
+ };
+@@ -395,7 +393,7 @@ export const PowerFlagFee = {
+     return {
+       powerFlag: isSet(object.powerFlag) ? String(object.powerFlag) : '',
+       fee: Array.isArray(object?.fee)
+-        ? object.fee.map((e) => Coin.fromJSON(e))
++        ? object.fee.map(e => Coin.fromJSON(e))
+         : [],
+     };
+   },
+@@ -403,7 +401,7 @@ export const PowerFlagFee = {
+     const obj = {};
+     message.powerFlag !== undefined && (obj.powerFlag = message.powerFlag);
+     if (message.fee) {
+-      obj.fee = message.fee.map((e) => (e ? Coin.toJSON(e) : undefined));
++      obj.fee = message.fee.map(e => (e ? Coin.toJSON(e) : undefined));
+     } else {
+       obj.fee = [];
+     }
+@@ -412,7 +410,7 @@ export const PowerFlagFee = {
+   fromPartial(object) {
+     const message = createBasePowerFlagFee();
+     message.powerFlag = object.powerFlag ?? '';
+-    message.fee = object.fee?.map((e) => Coin.fromPartial(e)) || [];
++    message.fee = object.fee?.map(e => Coin.fromPartial(e)) || [];
+     return message;
+   },
+ };
+@@ -514,7 +512,7 @@ export const Egress = {
+         ? bytesFromBase64(object.peer)
+         : new Uint8Array(),
+       powerFlags: Array.isArray(object?.powerFlags)
+-        ? object.powerFlags.map((e) => String(e))
++        ? object.powerFlags.map(e => String(e))
+         : [],
+     };
+   },
+@@ -526,7 +524,7 @@ export const Egress = {
+         message.peer !== undefined ? message.peer : new Uint8Array(),
+       ));
+     if (message.powerFlags) {
+-      obj.powerFlags = message.powerFlags.map((e) => e);
++      obj.powerFlags = message.powerFlags.map(e => e);
+     } else {
+       obj.powerFlags = [];
+     }
+@@ -536,14 +534,14 @@ export const Egress = {
+     const message = createBaseEgress();
+     message.nickname = object.nickname ?? '';
+     message.peer = object.peer ?? new Uint8Array();
+-    message.powerFlags = object.powerFlags?.map((e) => e) || [];
++    message.powerFlags = object.powerFlags?.map(e => e) || [];
+     return message;
+   },
+ };
+-function createBaseExtensionSnapshotterArtifactPayload() {
++function createBaseSwingStoreArtifact() {
+   return { name: '', data: new Uint8Array() };
+ }
+-export const ExtensionSnapshotterArtifactPayload = {
++export const SwingStoreArtifact = {
+   encode(message, writer = _m0.Writer.create()) {
+     if (message.name !== '') {
+       writer.uint32(10).string(message.name);
+@@ -556,7 +554,7 @@ export const ExtensionSnapshotterArtifactPayload = {
+   decode(input, length) {
+     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+     let end = length === undefined ? reader.len : reader.pos + length;
+-    const message = createBaseExtensionSnapshotterArtifactPayload();
++    const message = createBaseSwingStoreArtifact();
+     while (reader.pos < end) {
+       const tag = reader.uint32();
+       switch (tag >>> 3) {
+@@ -591,7 +589,7 @@ export const ExtensionSnapshotterArtifactPayload = {
+     return obj;
+   },
+   fromPartial(object) {
+-    const message = createBaseExtensionSnapshotterArtifactPayload();
++    const message = createBaseSwingStoreArtifact();
+     message.name = object.name ?? '';
+     message.data = object.data ?? new Uint8Array();
+     return message;
+@@ -629,7 +627,7 @@ function base64FromBytes(arr) {
+     return globalThis.Buffer.from(arr).toString('base64');
+   } else {
+     const bin = [];
+-    arr.forEach((byte) => {
++    arr.forEach(byte => {
+       bin.push(String.fromCharCode(byte));
+     });
+     return globalThis.btoa(bin.join(''));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
   makeFeeObject,
 } from "./lib/messageBuilder";
 import { isValidBundle } from "./utils/validate";
+import { compressBundle } from "./lib/compression";
 
 const App = () => {
   const { walletAddress, stargateClient } = useWallet();
@@ -42,8 +43,12 @@ const App = () => {
   async function handleBundle(vals: BundleFormArgs) {
     if (!walletAddress) throw new Error("wallet not connected");
     if (!isValidBundle(vals.bundle)) throw new Error("Invalid bundle.");
+    const { compressedBundle, uncompressedSize } = await compressBundle(
+      JSON.parse(vals.bundle)
+    );
     const proposalMsg = makeInstallBundleMsg({
-      bundle: JSON.stringify(JSON.parse(vals.bundle)),
+      compressedBundle,
+      uncompressedSize,
       submitter: walletAddress,
     });
     // @todo gas estiates

--- a/src/components/BundleForm.tsx
+++ b/src/components/BundleForm.tsx
@@ -3,7 +3,7 @@ import { CodeInput } from "./CodeInput";
 import { MsgInstallBundle } from "@agoric/cosmic-proto/swingset/msgs.js";
 import { Button } from "./Button";
 
-export type BundleFormArgs = Omit<MsgInstallBundle, "submitter">;
+export type BundleFormArgs = Pick<MsgInstallBundle, "bundle">;
 
 interface BundleFormProps {
   title: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,4 +20,10 @@ declare global {
       | "installBundle"
       | "parameterChangeProposal";
   }
+
+  interface BundleJson {
+    moduleFormat: string;
+    endoZipBase64: string;
+    endoZipBase64Sha512: string;
+  }
 }

--- a/src/lib/compression.ts
+++ b/src/lib/compression.ts
@@ -1,0 +1,38 @@
+const stringToBlob = (text: string): Blob => {
+  return new Blob([text], { type: "application/json" });
+};
+
+const compressBlob = async (content: Blob): Promise<Blob> => {
+  const cs = new CompressionStream("gzip");
+  const compressedStream = content.stream().pipeThrough(cs);
+  return new Response(compressedStream).blob();
+};
+
+export const blobToBase64 = async (blob: Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = function () {
+      const base64data = (reader.result as string).split(",")[1];
+      resolve(base64data);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+};
+
+async function blobToUint8Array(blob: Blob): Promise<Uint8Array> {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+export const compressBundle = async (
+  bundleJson: BundleJson
+): Promise<{ compressedBundle: Uint8Array; uncompressedSize: string }> => {
+  const uncompressedBlob = stringToBlob(JSON.stringify(bundleJson));
+  const compressedBlob = await compressBlob(uncompressedBlob);
+  const compressedBundle = await blobToUint8Array(compressedBlob);
+
+  return {
+    compressedBundle,
+    uncompressedSize: String(uncompressedBlob.size),
+  };
+};

--- a/src/lib/messageBuilder.ts
+++ b/src/lib/messageBuilder.ts
@@ -72,23 +72,40 @@ export const makeCoreEvalProposalMsg = ({
 });
 
 export interface MsgInstallArgs {
-  bundle: string;
+  compressedBundle: Uint8Array;
+  uncompressedSize: string;
   submitter: string;
 }
 
+// results in error: "Submitter address cannot be empty"
+// export const makeInstallBundleMsg = ({
+//   compressedBundle,
+//   uncompressedSize,
+//   submitter,
+// }: MsgInstallArgs) => ({
+//   typeUrl: "/agoric.swingset.MsgInstallBundle",
+//   value: Uint8Array.from(
+//     MsgInstallBundle.encode(
+//       MsgInstallBundle.fromPartial({
+//         compressedBundle,
+//         uncompressedSize,
+//         submitter: fromBech32(submitter).data,
+//       })
+//     ).finish()
+//   ),
+// });
+
 export const makeInstallBundleMsg = ({
-  bundle,
+  compressedBundle,
+  uncompressedSize,
   submitter,
 }: MsgInstallArgs) => ({
   typeUrl: "/agoric.swingset.MsgInstallBundle",
-  value: Uint8Array.from(
-    MsgInstallBundle.encode(
-      MsgInstallBundle.fromPartial({
-        bundle,
-        submitter: fromBech32(submitter).data,
-      })
-    ).finish()
-  ),
+  value: {
+    compressedBundle,
+    uncompressedSize,
+    submitter: fromBech32(submitter).data,
+  },
 });
 
 interface MakeFeeObjectArgs {
@@ -102,4 +119,3 @@ export const makeFeeObject = ({ denom, amount, gas }: MakeFeeObjectArgs) =>
     amount: coins(amount || 2000, denom || "ubld"),
     gas: gas ? String(gas) : "180000",
   } as StdFee);
-

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,5 +1,5 @@
 export const isValidBundle = (bundleJson: string): boolean => {
-  let parsed;
+  let parsed: BundleJson;
   try {
     parsed = JSON.parse(bundleJson);
   } catch {


### PR DESCRIPTION
-fix: bundle install msg 
- uses compressedBundle (Unit8Array) and uncompressedSize (string) instead of bundle for MsgInstallBundle
- updates @agoric/cosmic-proto via patch-package to include new compressBundle proto
- does not use MsgInstallBundle.(encode|partial), as this results in 'Submitter address cannot be empty' error
- adds compression logic for bundles, h/t @dckc https://gist.github.com/dckc/5eb31c216f4bf10e8f7a0ff82ced6108#file-unbundle-js

- closes #2